### PR TITLE
Improve HTTP error handling

### DIFF
--- a/lib/remote.js
+++ b/lib/remote.js
@@ -28,11 +28,21 @@ module.exports = function (log) {
     }, function (err, resp, body) {
       if (err) {
         log.error('Freight failed to connect to', url);
-
         defer.reject(err);
       } else {
-        log.debug('Response:', body);
-        defer.resolve(body);
+        log.debug('Response status:', resp.statusCode);
+        log.debug('Response body:', body);
+        switch (resp.statusCode) {
+          case 200:
+            defer.resolve(body);
+            break;
+          case 413:
+            defer.reject('Bundle too large to transmit. Try increasing `limit` on your Freight server.')
+            break;
+          default:
+            defer.reject('Unexpected response: ' + resp.statusCode);
+            break;
+        }
       }
     });
 


### PR DESCRIPTION
The `request` module only sets `err` if there was a connection error. Error-range HTTP status codes do not set this value, so errors like the `413 Request body too large` error would `resolve` and result in an incorrect 'Freight server password incorrect' error being displayed.

This switch allows us to intelligently handle HTTP errors. I've added a handler for the `413` case to refer to my enhancement in https://github.com/vladikoff/freight-server/pull/11.

CC: @michelle @slexaxton